### PR TITLE
Allow to have empty group exclude suffix

### DIFF
--- a/cmd/gke-identity-service-migrator/main.go
+++ b/cmd/gke-identity-service-migrator/main.go
@@ -533,7 +533,7 @@ func (r *subjectRecognizer) GetFederatedGroup(sub rbacv1.Subject) (string, bool)
 	if !strings.HasPrefix(sub.Name, r.groupsIncludePrefix) {
 		return "", false
 	}
-	if strings.HasSuffix(sub.Name, r.groupsExcludeSuffix) {
+	if r.groupsExcludeSuffix != "" && strings.HasSuffix(sub.Name, r.groupsExcludeSuffix) {
 		return "", false
 	}
 	return strings.TrimPrefix(sub.Name, r.groupsIncludePrefix), true


### PR DESCRIPTION
In some cases, users don't have suffix on groups. If they don't set any, it will fail becase by default the group will match the empty group exclude suffix.
With this change, if the group exclude suffix is empty or not set, it will not take this exclude filter into account.